### PR TITLE
Feature/#35

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,16 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**", // 모든 https 도메인 허용 (개발용)
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.0.0",
     "styled-components": "^6.1.18",
     "styled-system": "^5.1.5",
+    "swiper": "^11.2.10",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chromatic": "npx chromatic --project-token=chpt_78d51c6a0390b0f"
   },
   "dependencies": {
+    "@iconify/react": "^6.0.0",
     "@storybook/blocks": "^9.0.0-alpha.17",
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",

--- a/src/app/myroad/[myroadid]/page.tsx
+++ b/src/app/myroad/[myroadid]/page.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface MyRoadDetailPageProps {
+  params: {
+    myroadid: string;
+  };
+}
+
+export default function MyRoadDetailPage({ params }: MyRoadDetailPageProps) {
+  const { myroadid } = params;
+
+  return (
+    <div>
+      <h1>MyRoad 상세 페이지</h1>
+      <p>Detail ID: {myroadid}</p>
+    </div>
+  );
+}

--- a/src/app/myroad/[myroadid]/page.tsx
+++ b/src/app/myroad/[myroadid]/page.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 
 interface MyRoadDetailPageProps {
-  params: {
+  params: Promise<{
     myroadid: string;
-  };
+  }>;
 }
 
-export default function MyRoadDetailPage({ params }: MyRoadDetailPageProps) {
-  const { myroadid } = params;
+export default async function MyRoadDetailPage({
+  params,
+}: MyRoadDetailPageProps) {
+  const { myroadid } = await params;
 
   return (
     <div>

--- a/src/app/myroad/page.tsx
+++ b/src/app/myroad/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import MyRoadScreen from "@/screen/myroad/MyRoadScreen";
+
+export default function MyRoad() {
+  return <MyRoadScreen />;
+}

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -15,7 +15,7 @@ export default function KakaoLogin() {
       postUserMutation(code);
     }
     router.push("/");
-  }, [code]);
+  }, [code, postUserMutation, router]);
 
   return <></>;
 }

--- a/src/component/common/Header.styles.tsx
+++ b/src/component/common/Header.styles.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components"
+import styled from "styled-components";
 
 export const HeaderContainer = styled.header`
   width: 100%;
@@ -11,13 +11,14 @@ export const HeaderContainer = styled.header`
   justify-content: space-between;
   align-items: center;
   padding: 8px 20px;
+  height: 41px;
 `;
 
 export const HeaderLogo = styled.h1`
- font-weight: extra-bold;
- font-size: 15px;
- color: #0047AB;
-`
+  font-weight: extra-bold;
+  font-size: 15px;
+  color: #0047ab;
+`;
 
 export const LanguageBtn = styled.button`
   border: none;
@@ -25,15 +26,15 @@ export const LanguageBtn = styled.button`
   height: auto;
   display: block;
   position: relative;
-`
+`;
 export const Depth = styled.ul`
   background-color: #fff;
   border: 1px solid #ddd;
   padding: 5px 10px;
   position: absolute;
   top: 58px;
-  right:0;
-`
+  right: 0;
+`;
 
 export const DepthBtn = styled.li`
   display: block;
@@ -47,4 +48,4 @@ export const DepthBtn = styled.li`
     text-decoration: underline;
     color: black;
   }
-`
+`;

--- a/src/component/common/IconifyIcon.tsx
+++ b/src/component/common/IconifyIcon.tsx
@@ -2,10 +2,7 @@ import { Icon as IconifyIcon } from "@iconify/react";
 import styled from "styled-components";
 import { ITagProps } from "@/styles/BaseStyledTags";
 
-// styled-system과 호환되는 Icon 컴포넌트
-const StyledIcon = styled(IconifyIcon)<ITagProps>`
-  /* styled-system props가 자동으로 적용됩니다 */
-`;
+const StyledIcon = styled(IconifyIcon)<ITagProps>``;
 
 interface IconProps extends ITagProps {
   icon: string;

--- a/src/component/common/IconifyIcon.tsx
+++ b/src/component/common/IconifyIcon.tsx
@@ -1,0 +1,33 @@
+import { Icon as IconifyIcon } from "@iconify/react";
+import styled from "styled-components";
+import { ITagProps } from "@/styles/BaseStyledTags";
+
+// styled-system과 호환되는 Icon 컴포넌트
+const StyledIcon = styled(IconifyIcon)<ITagProps>`
+  /* styled-system props가 자동으로 적용됩니다 */
+`;
+
+interface IconProps extends ITagProps {
+  icon: string;
+  width?: number | string;
+  height?: number | string;
+  color?: string;
+}
+
+export default function Icon({
+  icon,
+  width = 24,
+  height = 24,
+  color,
+  ...props
+}: IconProps) {
+  return (
+    <StyledIcon
+      icon={icon}
+      width={width}
+      height={height}
+      style={{ color }}
+      {...props}
+    />
+  );
+}

--- a/src/component/common/Layout.tsx
+++ b/src/component/common/Layout.tsx
@@ -20,7 +20,7 @@ const Main = styled.main`
   flex-direction: column;
   max-width: 780px;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   margin: 0 auto;
   position: relative;
 `;

--- a/src/component/common/Layout.tsx
+++ b/src/component/common/Layout.tsx
@@ -31,6 +31,6 @@ const ContentContainer = styled(CenterColumn)`
   max-width: 780px;
   overflow-y: auto;
   padding-top: 41px; /* 실제 헤더 높이에 맞게 조정 필요 */
-  padding-bottom: 47px; /* 실제 탭바 높이에 맞게 조정 필요 */
+  padding-bottom: 70px; /* 실제 탭바 높이에 맞게 조정 필요 */
   min-height: 0;
 `;

--- a/src/component/common/Layout.tsx
+++ b/src/component/common/Layout.tsx
@@ -31,6 +31,6 @@ const ContentContainer = styled(CenterColumn)`
   max-width: 780px;
   overflow-y: auto;
   padding-top: 41px; /* 실제 헤더 높이에 맞게 조정 필요 */
-  padding-bottom: 47px; /* 실제 헤더 높이에 맞게 조정 필요 */
+  padding-bottom: 47px; /* 실제 탭바 높이에 맞게 조정 필요 */
   min-height: 0;
 `;

--- a/src/component/myroad/list/Category.tsx
+++ b/src/component/myroad/list/Category.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+
+import { CenterColumn, Row } from "@/styles/BaseComponents";
+import { Font } from "@/styles/Typography";
+import colors from "@/styles/Colors";
+
+export default function Category() {
+  const categories = [
+    {
+      id: 1,
+      name: "# 힐링",
+    },
+    {
+      id: 2,
+      name: "# 도심속",
+    },
+    {
+      id: 3,
+      name: "# 혼자만의 시간",
+    },
+    {
+      id: 4,
+      name: "# 드라이브",
+    },
+    {
+      id: 5,
+      name: "# 캠핑",
+    },
+    {
+      id: 6,
+      name: "# 가짜데이터1",
+    },
+    {
+      id: 7,
+      name: "# 가짜데이터2",
+    },
+    {
+      id: 8,
+      name: "# 가짜데이터3",
+    },
+  ];
+
+  const [selectedCategory, setSelectedCategory] = useState(categories[0]);
+
+  return (
+    <Row
+      height="47px"
+      width="100%"
+      border={`1px solid ${colors.gray_300}`}
+      px="30px"
+      gridGap="6px"
+      overflow="auto"
+    >
+      {categories.map((category) => (
+        <CenterColumn width="fit-content" height="36px" key={category.id}>
+          <Font
+            typo="c02_m"
+            color="gray_300"
+            onClick={() => setSelectedCategory(category)}
+            $active={selectedCategory.id === category.id}
+          >
+            {category.name}
+          </Font>
+        </CenterColumn>
+      ))}
+    </Row>
+  );
+}

--- a/src/component/myroad/list/Category.tsx
+++ b/src/component/myroad/list/Category.tsx
@@ -62,7 +62,7 @@ export default function Category() {
     <Row
       height="47px"
       width="100%"
-      border={`1px solid ${colors.gray_300}`}
+      borderY={`1px solid ${colors.gray_300}`}
       px="15px"
       gridGap="6px"
       overflow="auto"

--- a/src/component/myroad/list/Category.tsx
+++ b/src/component/myroad/list/Category.tsx
@@ -3,40 +3,49 @@ import React, { useState } from "react";
 import { CenterColumn, Row } from "@/styles/BaseComponents";
 import { Font } from "@/styles/Typography";
 import colors from "@/styles/Colors";
+import Icon from "@/component/common/IconifyIcon";
 
 export default function Category() {
   const categories = [
     {
       id: 1,
       name: "# 힐링",
+      icon: "ph:leaf-fill",
     },
     {
       id: 2,
       name: "# 도심속",
+      icon: "ph:buildings-fill",
     },
     {
       id: 3,
       name: "# 혼자만의 시간",
+      icon: "ph:person-fill",
     },
     {
       id: 4,
       name: "# 드라이브",
+      icon: "ph:car-fill",
     },
     {
       id: 5,
       name: "# 캠핑",
+      icon: "ph:tent-fill",
     },
     {
       id: 6,
       name: "# 가짜데이터1",
+      icon: "ph:star-fill",
     },
     {
       id: 7,
       name: "# 가짜데이터2",
+      icon: "ph:heart-fill",
     },
     {
       id: 8,
       name: "# 가짜데이터3",
+      icon: "ph:lightning-fill",
     },
   ];
 
@@ -52,11 +61,28 @@ export default function Category() {
       overflow="auto"
     >
       {categories.map((category) => (
-        <CenterColumn width="fit-content" height="36px" key={category.id}>
+        <CenterColumn
+          width="fit-content"
+          height="auto"
+          key={category.id}
+          onClick={() => setSelectedCategory(category)}
+          style={{ cursor: "pointer" }}
+        >
+          <Icon
+            icon={category.icon}
+            width={20}
+            height={20}
+            color={
+              selectedCategory.id === category.id
+                ? colors.blue_500
+                : colors.gray_300
+            }
+            mb="4px"
+          />
+
           <Font
             typo="c02_m"
             color="gray_300"
-            onClick={() => setSelectedCategory(category)}
             $active={selectedCategory.id === category.id}
           >
             {category.name}

--- a/src/component/myroad/list/Category.tsx
+++ b/src/component/myroad/list/Category.tsx
@@ -66,6 +66,10 @@ export default function Category() {
       px="15px"
       gridGap="6px"
       overflow="auto"
+      position="sticky"
+      top="0"
+      zIndex="10"
+      backgroundColor="white"
     >
       {categories.map((category) => (
         <CenterColumn

--- a/src/component/myroad/list/Category.tsx
+++ b/src/component/myroad/list/Category.tsx
@@ -6,57 +6,64 @@ import colors from "@/styles/Colors";
 import Icon from "@/component/common/IconifyIcon";
 
 export default function Category() {
-  const categories = [
+  const [selectedCategory, setSelectedCategory] = useState({ id: 1 });
+
+  const getCategories = () => [
     {
       id: 1,
-      name: "# 힐링",
-      icon: "ph:leaf-fill",
+      name: "#힐링",
+      icon: "tdesign:feel-at-ease-filled",
     },
     {
       id: 2,
-      name: "# 도심속",
-      icon: "ph:buildings-fill",
+      name: "#도심속",
+      icon: "mdi:city",
     },
     {
       id: 3,
-      name: "# 혼자만의 시간",
-      icon: "ph:person-fill",
+      name: "#혼자만의 시간",
+      icon: "streamline-ultimate:single-woman-home-bold",
     },
     {
       id: 4,
-      name: "# 드라이브",
-      icon: "ph:car-fill",
+      name: "#드라이브",
+      icon: "material-symbols:unpaved-road",
     },
     {
       id: 5,
-      name: "# 캠핑",
+      name: "#캠핑",
       icon: "ph:tent-fill",
     },
     {
       id: 6,
-      name: "# 가짜데이터1",
-      icon: "ph:star-fill",
+      name: "#가짜데이터1",
+      icon: "ph:tent-fill",
     },
     {
       id: 7,
-      name: "# 가짜데이터2",
-      icon: "ph:heart-fill",
+      name: "#가짜데이터2",
+      icon: "ph:tent-fill",
     },
     {
       id: 8,
-      name: "# 가짜데이터3",
-      icon: "ph:lightning-fill",
+      name: "#가짜데이터3",
+      icon: "ph:tent-fill",
+    },
+    {
+      id: 9,
+      name: "#가짜데이터4",
+      icon: "ph:tent-fill",
     },
   ];
 
-  const [selectedCategory, setSelectedCategory] = useState(categories[0]);
+  const categories = getCategories();
 
   return (
     <Row
       height="47px"
       width="100%"
       border={`1px solid ${colors.gray_300}`}
-      px="30px"
+      px="15px"
       gridGap="6px"
       overflow="auto"
     >
@@ -64,6 +71,8 @@ export default function Category() {
         <CenterColumn
           width="fit-content"
           height="auto"
+          minWidth="fit-content"
+          flexShrink={0}
           key={category.id}
           onClick={() => setSelectedCategory(category)}
           style={{ cursor: "pointer" }}

--- a/src/component/myroad/list/ImgSwiper.tsx
+++ b/src/component/myroad/list/ImgSwiper.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Pagination, Navigation } from "swiper/modules";
+import styled from "styled-components";
+
+import "swiper/css";
+import "swiper/css/pagination";
+import "swiper/css/navigation";
+
+import { Div } from "@/styles/BaseStyledTags";
+import colors from "@/styles/Colors";
+
+interface ImgSwiperProps {
+  img: string[];
+}
+
+export default function ImgSwiper({ img }: ImgSwiperProps) {
+  return (
+    <StyledSwiperContainer width="100%" position="relative">
+      <Swiper
+        modules={[Pagination, Navigation]}
+        spaceBetween={10}
+        slidesPerView={1}
+        centeredSlides={true}
+        pagination={{
+          clickable: true,
+          dynamicBullets: true,
+        }}
+        navigation={true}
+        style={{
+          width: "100%",
+          overflow: "hidden",
+        }}
+      >
+        {img.map((item, index) => (
+          <SwiperSlide key={index}>
+            <Image
+              src={item}
+              alt={`이미지 ${index + 1}`}
+              width={0}
+              height={0}
+              sizes="100vw"
+              style={{
+                width: "100%",
+                height: "auto",
+                maxHeight: "270px",
+                objectFit: "contain",
+              }}
+            />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </StyledSwiperContainer>
+  );
+}
+
+const StyledSwiperContainer = styled(Div)`
+  .swiper {
+    overflow: hidden;
+    border-radius: 12px;
+  }
+
+  .swiper-wrapper {
+    overflow: visible;
+  }
+
+  .swiper-slide {
+    overflow: hidden;
+    width: 100% !important;
+    max-width: 100%;
+    height: auto !important;
+    display: block;
+  }
+
+  .swiper-button-next,
+  .swiper-button-prev {
+    width: 32px;
+    height: 32px;
+    background: ${colors.white};
+    border-radius: 50%;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    color: ${colors.gray_500};
+    font-size: 14px;
+    font-weight: bold;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+
+    &:after {
+      font-size: 12px;
+      font-weight: 900;
+    }
+
+    &:hover {
+      background: ${colors.blue_500};
+      color: ${colors.white};
+      transform: scale(1.1);
+      transition: all 0.2s ease;
+    }
+
+    &.swiper-button-disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+      &:hover {
+        background: ${colors.white};
+        color: ${colors.gray_500};
+        transform: none;
+      }
+    }
+  }
+
+  .swiper-button-next {
+    right: 8px;
+  }
+
+  .swiper-button-prev {
+    left: 8px;
+  }
+
+  .swiper-pagination {
+    bottom: 12px;
+
+    .swiper-pagination-bullet {
+      width: 8px;
+      height: 8px;
+      background: rgba(255, 255, 255, 0.5);
+      opacity: 1;
+      transition: all 0.2s ease;
+
+      &.swiper-pagination-bullet-active {
+        background: ${colors.white};
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      }
+    }
+  }
+`;

--- a/src/component/myroad/list/ListItem.tsx
+++ b/src/component/myroad/list/ListItem.tsx
@@ -1,13 +1,14 @@
-import { CenterColumn, Column, Row } from "@/styles/BaseComponents";
+import { Column } from "@/styles/BaseComponents";
 import { Font } from "@/styles/Typography";
 import Image from "next/image";
 import React from "react";
 import colors from "@/styles/Colors";
 import TopInfo from "@/component/myroad/list/TopInfo";
+import ImgSwiper from "./ImgSwiper";
 
 interface ListItemData {
   id: number;
-  img: string;
+  img: string[];
   title: string;
   tags: string[];
   detailId: string;
@@ -30,19 +31,7 @@ export default function ListItem({
       gridGap="15px"
     >
       <TopInfo title={listItemData.title} detailId={listItemData.detailId} />
-
-      <Image
-        src={listItemData.img}
-        alt={listItemData.title}
-        width={100}
-        height={100}
-        style={{
-          borderRadius: "4px",
-          objectFit: "cover" as any,
-          flexShrink: 0,
-        }}
-      />
-
+      <ImgSwiper img={listItemData.img} />
       <Column width="100%" maxWidth="100%" flexShrink={0}>
         <Font
           typo="l01_m"

--- a/src/component/myroad/list/ListItem.tsx
+++ b/src/component/myroad/list/ListItem.tsx
@@ -1,10 +1,12 @@
 import { Column } from "@/styles/BaseComponents";
-import { Font } from "@/styles/Typography";
-import Image from "next/image";
+
 import React from "react";
+
 import colors from "@/styles/Colors";
+
 import TopInfo from "@/component/myroad/list/TopInfo";
-import ImgSwiper from "./ImgSwiper";
+import ImgSwiper from "@/component/myroad/list/ImgSwiper";
+import TagWrapper from "@/component/myroad/list/TagWrapper";
 
 interface ListItemData {
   id: number;
@@ -32,23 +34,7 @@ export default function ListItem({
     >
       <TopInfo title={listItemData.title} detailId={listItemData.detailId} />
       <ImgSwiper img={listItemData.img} />
-      <Column width="100%" maxWidth="100%" flexShrink={0}>
-        <Font
-          typo="l01_m"
-          color="gray_500"
-          overflow="hidden"
-          display="-webkit-box"
-          style={{
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical" as any,
-            wordBreak: "break-word",
-            whiteSpace: "normal",
-            textOverflow: "ellipsis",
-          }}
-        >
-          {listItemData.tags.join(" ")}
-        </Font>
-      </Column>
+      <TagWrapper tags={listItemData.tags} />
     </Column>
   );
 }

--- a/src/component/myroad/list/ListItem.tsx
+++ b/src/component/myroad/list/ListItem.tsx
@@ -1,0 +1,65 @@
+import { CenterColumn, Column, Row } from "@/styles/BaseComponents";
+import { Font } from "@/styles/Typography";
+import Image from "next/image";
+import React from "react";
+import colors from "@/styles/Colors";
+import TopInfo from "@/component/myroad/list/TopInfo";
+
+interface ListItemData {
+  id: number;
+  img: string;
+  title: string;
+  tags: string[];
+  detailId: string;
+}
+
+export default function ListItem({
+  listItemData,
+}: {
+  listItemData: ListItemData;
+}) {
+  return (
+    <Column
+      key={listItemData.id}
+      width="100%"
+      p="7px"
+      border={`1px solid ${colors.gray_200}`}
+      borderRadius="10px"
+      justifyContent="flex-start"
+      alignItems="flex-start"
+      gridGap="15px"
+    >
+      <TopInfo title={listItemData.title} detailId={listItemData.detailId} />
+
+      <Image
+        src={listItemData.img}
+        alt={listItemData.title}
+        width={100}
+        height={100}
+        style={{
+          borderRadius: "4px",
+          objectFit: "cover" as any,
+          flexShrink: 0,
+        }}
+      />
+
+      <Column width="100%" maxWidth="100%" flexShrink={0}>
+        <Font
+          typo="l01_m"
+          color="gray_500"
+          overflow="hidden"
+          display="-webkit-box"
+          style={{
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical" as any,
+            wordBreak: "break-word",
+            whiteSpace: "normal",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {listItemData.tags.join(" ")}
+        </Font>
+      </Column>
+    </Column>
+  );
+}

--- a/src/component/myroad/list/TagWrapper.tsx
+++ b/src/component/myroad/list/TagWrapper.tsx
@@ -1,0 +1,24 @@
+import { Row } from "@/styles/BaseComponents";
+import { Div } from "@/styles/BaseStyledTags";
+import colors from "@/styles/Colors";
+import { Font } from "@/styles/Typography";
+import React from "react";
+
+export default function TagWrapper({ tags }: { tags: string[] }) {
+  return (
+    <Row width="100%" flexWrap="wrap" gridGap="5px">
+      {tags.map((tag) => (
+        <Div
+          backgroundColor={colors.yellow_300}
+          borderRadius="10px"
+          padding="4px"
+          flexShrink="0"
+        >
+          <Font typo="c02_m" color="blue_500">
+            {tag}
+          </Font>
+        </Div>
+      ))}
+    </Row>
+  );
+}

--- a/src/component/myroad/list/TagWrapper.tsx
+++ b/src/component/myroad/list/TagWrapper.tsx
@@ -7,8 +7,9 @@ import React from "react";
 export default function TagWrapper({ tags }: { tags: string[] }) {
   return (
     <Row width="100%" flexWrap="wrap" gridGap="5px">
-      {tags.map((tag) => (
+      {tags.map((tag, index) => (
         <Div
+          key={index}
           backgroundColor={colors.yellow_300}
           borderRadius="10px"
           padding="4px"

--- a/src/component/myroad/list/TopInfo.tsx
+++ b/src/component/myroad/list/TopInfo.tsx
@@ -1,0 +1,55 @@
+import Icon from "@/component/common/IconifyIcon";
+import { Row } from "@/styles/BaseComponents";
+import { Font } from "@/styles/Typography";
+import colors from "@/styles/Colors";
+import React from "react";
+
+interface TopInfoProps {
+  title: string;
+  detailId: string;
+}
+
+export default function TopInfo({ title, detailId }: TopInfoProps) {
+  return (
+    <Row
+      width="100%"
+      alignItems="center"
+      gridGap="4px"
+      justifyContent="space-between"
+    >
+      <Font
+        typo="t01_bold_m"
+        color="black"
+        overflow="hidden"
+        display="-webkit-box"
+        style={{
+          WebkitLineClamp: 1,
+          WebkitBoxOrient: "vertical",
+          wordBreak: "break-word",
+          whiteSpace: "normal",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {title}
+      </Font>
+      <Row
+        alignItems="center"
+        gridGap="4px"
+        backgroundColor={colors.gray_100}
+        borderRadius="999px"
+        padding="4px"
+        flexShrink="0"
+      >
+        <Font typo="c01_m" color="blue_500">
+          상세코스 {detailId}
+        </Font>
+        <Icon
+          icon="line-md:logout"
+          width={10}
+          height={10}
+          color={colors.blue_500}
+        />
+      </Row>
+    </Row>
+  );
+}

--- a/src/component/myroad/list/TopInfo.tsx
+++ b/src/component/myroad/list/TopInfo.tsx
@@ -3,6 +3,7 @@ import { Row } from "@/styles/BaseComponents";
 import { Font } from "@/styles/Typography";
 import colors from "@/styles/Colors";
 import React from "react";
+import { useRouter } from "next/navigation";
 
 interface TopInfoProps {
   title: string;
@@ -10,6 +11,10 @@ interface TopInfoProps {
 }
 
 export default function TopInfo({ title, detailId }: TopInfoProps) {
+  const router = useRouter();
+  const onClickDetail = () => {
+    router.push(`/myroad/${detailId}`);
+  };
   return (
     <Row
       width="100%"
@@ -39,9 +44,11 @@ export default function TopInfo({ title, detailId }: TopInfoProps) {
         borderRadius="999px"
         padding="4px"
         flexShrink="0"
+        onClick={onClickDetail}
+        style={{ cursor: "pointer" }}
       >
         <Font typo="c01_m" color="blue_500">
-          상세코스 {detailId}
+          상세코스
         </Font>
         <Icon
           icon="line-md:logout"

--- a/src/screen/myroad/MyRoadScreen.tsx
+++ b/src/screen/myroad/MyRoadScreen.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-import { CenterColumn, Column } from "@/styles/BaseComponents";
+import { Column } from "@/styles/BaseComponents";
 
 import Category from "@/component/myroad/list/Category";
 import ListItem from "@/component/myroad/list/ListItem";

--- a/src/screen/myroad/MyRoadScreen.tsx
+++ b/src/screen/myroad/MyRoadScreen.tsx
@@ -12,7 +12,11 @@ export default function MyRoadScreen() {
   const listItemData = [
     {
       id: 1,
-      img: "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+      img: [
+        "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+        "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+        "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+      ],
       title: "🎨 루브르 박물관 관람 가이드",
       tags: [
         "#힐링",
@@ -31,7 +35,9 @@ export default function MyRoadScreen() {
     },
     {
       id: 2,
-      img: "https://ojsfile.ohmynews.com/PHT_IMG_FILE/2023/1108/IE003225955_PHT.jpg",
+      img: [
+        "https://ojsfile.ohmynews.com/PHT_IMG_FILE/2023/1108/IE003225955_PHT.jpg",
+      ],
       title: "서울 도심 속 가이드",
       tags: ["#혼자만의 시간", "#드라이브"],
       detailId: "14",
@@ -39,14 +45,21 @@ export default function MyRoadScreen() {
 
     {
       id: 3,
-      img: "https://thumb.tidesquare.com/common_cdn/upload/image/theme/2023/02/10/%E1%84%90%E1%85%A6%E1%84%86%E1%85%A1_%E1%84%80%E1%85%B5%E1%84%92%E1%85%AC%E1%86%A8%E1%84%8C%E1%85%A5%E1%86%AB_%E1%84%89%E1%85%A1%E1%86%BC%E1%84%83%E1%85%A1%E1%86%AB_%E1%84%87%E1%85%A2%E1%84%82%E1%85%A5_(750_X_500)_20230210095743.png",
+      img: [
+        "https://thumb.tidesquare.com/common_cdn/upload/image/theme/2023/02/10/%E1%84%90%E1%85%A6%E1%84%86%E1%85%A1_%E1%84%80%E1%85%B5%E1%84%92%E1%85%AC%E1%86%A8%E1%84%8C%E1%85%A5%E1%86%AB_%E1%84%89%E1%85%A1%E1%86%BC%E1%84%83%E1%85%A1%E1%86%AB_%E1%84%87%E1%85%A2%E1%84%82%E1%85%A5_(750_X_500)_20230210095743.png",
+        "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+        "https://ojsfile.ohmynews.com/PHT_IMG_FILE/2023/1108/IE003225955_PHT.jpg",
+      ],
       title: "홍콩 야경",
       tags: ["#홍콩", "#혼자만의 시간"],
       detailId: "34",
     },
     {
       id: 4,
-      img: "https://media.istockphoto.com/id/1300107681/ko/%EC%82%AC%EC%A7%84/%EB%8C%80%EC%84%9C%EC%96%91-%EC%9D%98-%ED%91%9C%EB%A9%B4.jpg?s=612x612&w=0&k=20&c=p_vW3L_1A7moSNqHpavoW8EmmiiKOM4bwQM7rSvt5OY=",
+      img: [
+        "https://media.istockphoto.com/id/1300107681/ko/%EC%82%AC%EC%A7%84/%EB%8C%80%EC%84%9C%EC%96%91-%EC%9D%98-%ED%91%9C%EB%A9%B4.jpg?s=612x612&w=0&k=20&c=p_vW3L_1A7moSNqHpavoW8EmmiiKOM4bwQM7rSvt5OY=",
+        "https://thumb.tidesquare.com/common_cdn/upload/image/theme/2023/02/10/%E1%84%90%E1%85%A6%E1%84%86%E1%85%A1_%E1%84%80%E1%85%B5%E1%84%92%E1%85%AC%E1%86%A8%E1%84%8C%E1%85%A5%E1%86%AB_%E1%84%89%E1%85%A1%E1%86%BC%E1%84%83%E1%85%A1%E1%86%AB_%E1%84%87%E1%85%A2%E1%84%82%E1%85%A5_(750_X_500)_20230210095743.png",
+      ],
       title:
         "바다 여행 긴 제목 예시 바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시",
       tags: ["#혼자만의 시간", "#드라이브"],

--- a/src/screen/myroad/MyRoadScreen.tsx
+++ b/src/screen/myroad/MyRoadScreen.tsx
@@ -1,16 +1,75 @@
 "use client";
 
-import Category from "@/component/myroad/list/Category";
-import { CenterColumn } from "@/styles/BaseComponents";
 import React from "react";
 
+import { CenterColumn, Column } from "@/styles/BaseComponents";
+
+import Category from "@/component/myroad/list/Category";
+import ListItem from "@/component/myroad/list/ListItem";
+
 export default function MyRoadScreen() {
+  // todo: listItem 데이터 추가
+  const listItemData = [
+    {
+      id: 1,
+      img: "https://image.chosun.com/sitedata/image/201706/09/2017060903013_0.jpg",
+      title: "🎨 루브르 박물관 관람 가이드",
+      tags: [
+        "#힐링",
+        "#도심속",
+        "#홍콩",
+        "#혼자만의 시간",
+        "#홍콩",
+        "#혼자만의 시간",
+        "#홍콩",
+        "#혼자만의 시간",
+        "#홍콩",
+        "#혼자만의 시간",
+        "#홍콩",
+      ],
+      detailId: "12",
+    },
+    {
+      id: 2,
+      img: "https://ojsfile.ohmynews.com/PHT_IMG_FILE/2023/1108/IE003225955_PHT.jpg",
+      title: "서울 도심 속 가이드",
+      tags: ["#혼자만의 시간", "#드라이브"],
+      detailId: "14",
+    },
+
+    {
+      id: 3,
+      img: "https://thumb.tidesquare.com/common_cdn/upload/image/theme/2023/02/10/%E1%84%90%E1%85%A6%E1%84%86%E1%85%A1_%E1%84%80%E1%85%B5%E1%84%92%E1%85%AC%E1%86%A8%E1%84%8C%E1%85%A5%E1%86%AB_%E1%84%89%E1%85%A1%E1%86%BC%E1%84%83%E1%85%A1%E1%86%AB_%E1%84%87%E1%85%A2%E1%84%82%E1%85%A5_(750_X_500)_20230210095743.png",
+      title: "홍콩 야경",
+      tags: ["#홍콩", "#혼자만의 시간"],
+      detailId: "34",
+    },
+    {
+      id: 4,
+      img: "https://media.istockphoto.com/id/1300107681/ko/%EC%82%AC%EC%A7%84/%EB%8C%80%EC%84%9C%EC%96%91-%EC%9D%98-%ED%91%9C%EB%A9%B4.jpg?s=612x612&w=0&k=20&c=p_vW3L_1A7moSNqHpavoW8EmmiiKOM4bwQM7rSvt5OY=",
+      title:
+        "바다 여행 긴 제목 예시 바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시바다 여행 긴 제목 예시",
+      tags: ["#혼자만의 시간", "#드라이브"],
+      detailId: "2",
+    },
+  ];
+
   return (
-    <CenterColumn width="100%" height="100%">
+    <Column width="100%" height="100%">
       <Category />
-      <CenterColumn width="100%" height="100%">
-        qldjTdma
-      </CenterColumn>
-    </CenterColumn>
+      <Column
+        width="100%"
+        height="100%"
+        gridGap="20px"
+        p="15px"
+        overflow="auto"
+        justifyContent="flex-start"
+        alignItems="center"
+      >
+        {listItemData.map((item) => (
+          <ListItem key={item.id} listItemData={item} />
+        ))}
+      </Column>
+    </Column>
   );
 }

--- a/src/screen/myroad/MyRoadScreen.tsx
+++ b/src/screen/myroad/MyRoadScreen.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import Category from "@/component/myroad/list/Category";
+import { CenterColumn } from "@/styles/BaseComponents";
+import React from "react";
+
+export default function MyRoadScreen() {
+  return (
+    <CenterColumn width="100%" height="100%">
+      <Category />
+    </CenterColumn>
+  );
+}

--- a/src/screen/myroad/MyRoadScreen.tsx
+++ b/src/screen/myroad/MyRoadScreen.tsx
@@ -8,6 +8,9 @@ export default function MyRoadScreen() {
   return (
     <CenterColumn width="100%" height="100%">
       <Category />
+      <CenterColumn width="100%" height="100%">
+        qldjTdma
+      </CenterColumn>
     </CenterColumn>
   );
 }

--- a/src/styles/BaseStyledTags.tsx
+++ b/src/styles/BaseStyledTags.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import styled, { css } from "styled-components";
 import {
@@ -21,7 +21,7 @@ import {
   position,
   space,
   typography,
-  variant
+  variant,
 } from "styled-system";
 import { Config } from "./FontVariants";
 
@@ -39,7 +39,7 @@ const styles = compose(
   space,
   typography,
   background,
-  variant(Config),
+  variant(Config)
 );
 export interface ITagProps
   extends ColorProps,
@@ -128,17 +128,4 @@ export function withStyle<T = object>(Component: React.ComponentType<T>) {
   `;
 }
 
-export {
-  A,
-  Button,
-  Div,
-  I,
-  Img,
-  Input,
-  Li,
-  Ol,
-  Option,
-  Span,
-  TextArea,
-  Ul,
-};
+export { A, Button, Div, I, Img, Input, Li, Ol, Option, Span, TextArea, Ul };

--- a/src/styles/ClientLayout.tsx
+++ b/src/styles/ClientLayout.tsx
@@ -1,36 +1,30 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { useServerInsertedHTML } from 'next/navigation'
-import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
-import { noto_300 } from "./Typography"
+import { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+import { noto_kr } from "./Typography";
 
 export default function ClientLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
-  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
 
   useServerInsertedHTML(() => {
-    const styles = styledComponentsStyleSheet.getStyleElement()
-    styledComponentsStyleSheet.instance.clearTag()
-    return <>{styles}</>
-  })
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
 
-  if (typeof window !== 'undefined') {
-    return (
-      <div className={noto_300.className}>
-        {children}
-      </div>
-    )
+  if (typeof window !== "undefined") {
+    return <div className={noto_kr.className}>{children}</div>;
   }
 
   return (
     <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
-      <div className={noto_300.className}>
-        {children}
-      </div>
+      <div className={noto_kr.className}>{children}</div>
     </StyleSheetManager>
-  )
+  );
 }

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -9,6 +9,7 @@ const colors = {
   gray_500: "#5F605B",
   gray_300: "#888888",
   gray_200: "#999999",
+  gray_100: "#CCCCCC",
 
   transparent: "#00000000",
 };

--- a/src/styles/FontVariants.ts
+++ b/src/styles/FontVariants.ts
@@ -5,46 +5,60 @@ interface ITypoProps {
 const Config = {
   prop: "typo",
   variants: {
-    m01_bold_m: { // Main Logo
-      fontFamily: "Nunito-Extra, sans-serif", 
+    m01_bold_m: {
+      // Main Logo
+      fontFamily: "Nunito-Extra, sans-serif",
       fontWeight: "700",
       fontSize: "35px",
       lineHeight: "normal",
     },
-    m01_m: { // Header-logo
-      fontFamily: "Nunito-Extra, sans-serif", 
+    m01_m: {
+      // Header-logo
+      fontFamily: "Nunito-Extra, sans-serif",
       fontWeight: "400",
       fontSize: "12px",
       lineHeight: "normal",
     },
-    c01_m: { // 캡션 주석등
+    c01_m: {
+      // 캡션 주석등
       fontFamily: "Noto Sans KR, sans-serif",
       fontWeight: "500",
       fontSize: "10px",
       lineHeight: "normal",
     },
-    l01_m: { // 일기 후기 평텍스트
+    l01_m: {
+      // 일기 후기 평텍스트
       fontFamily: "Noto Sans KR, sans-serif",
       fontWeight: "400",
       fontSize: "14px",
       lineHeight: "normal",
     },
-    l01_bold_m: { // 일기 후기 강조 텍스트
+    l01_bold_m: {
+      // 일기 후기 강조 텍스트
       fontFamily: "Noto Sans KR, sans-serif",
       fontWeight: "700",
       fontSize: "14px",
       lineHeight: "normal",
     },
-    t01_m: { // 제목, 질문 강조 텍스트
+    t01_m: {
+      // 제목, 질문 강조 텍스트
       fontFamily: "Noto Sans KR, sans-serif",
       fontWeight: "700",
       fontSize: "15px",
       lineHeight: "normal",
     },
-    t01_bold_m: { // 일기 제목
+    t01_bold_m: {
+      // 일기 제목
       fontFamily: "Noto Sans KR, sans-serif",
       fontWeight: "700",
       fontSize: "20px",
+      lineHeight: "normal",
+    },
+    c02_m: {
+      // 카테고리 텍스트
+      fontFamily: "Noto Sans KR, sans-serif",
+      fontWeight: "500",
+      fontSize: "9px",
       lineHeight: "normal",
     },
   },

--- a/src/styles/Typography.ts
+++ b/src/styles/Typography.ts
@@ -1,8 +1,9 @@
-'use client'
+"use client";
 
 import styled from "styled-components";
 import { Div } from "@/styles/BaseStyledTags";
 import { Noto_Sans_KR } from "next/font/google";
+import colors from "./Colors";
 
 const Default = styled(Div)`
   white-space: pre-line;
@@ -13,12 +14,14 @@ const Default = styled(Div)`
   letter-spacing: -0.1px;
 `;
 
-const Font = styled(Default)``;
+const Font = styled(Default)<{ $active?: boolean }>`
+  color: ${({ $active }) => ($active ? colors.blue_500 : colors.gray_300)};
+`;
 
-export const noto_300 = Noto_Sans_KR({
-  weight: "300",
+export const noto_kr = Noto_Sans_KR({
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
   subsets: ["latin"],
 });
-const fonts = { noto_300 };
+const fonts = { noto_kr };
 
 export { Font, fonts };

--- a/src/styles/Typography.ts
+++ b/src/styles/Typography.ts
@@ -14,8 +14,9 @@ const Default = styled(Div)`
   letter-spacing: -0.1px;
 `;
 
-const Font = styled(Default)<{ $active?: boolean }>`
-  color: ${({ $active }) => ($active ? colors.blue_500 : colors.gray_300)};
+const Font = styled(Default)<{ $active?: boolean; color?: string }>`
+  color: ${({ color, $active }) =>
+    color || ($active ? colors.blue_500 : colors.gray_300)};
 `;
 
 export const noto_kr = Noto_Sans_KR({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@iconify/react@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/react/-/react-6.0.0.tgz#8e7ed943792746a0401cc49b9b4e9a5bd5f09b1a"
+  integrity sha512-eqNscABVZS8eCpZLU/L5F5UokMS9mnCf56iS1nM9YYHdH8ZxqZL9zyjSwW60IOQFsXZkilbBiv+1paMXBhSQnw==
+  dependencies:
+    "@iconify/types" "^2.0.0"
+
+"@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
 "@img/sharp-darwin-arm64@0.34.2":
   version "0.34.2"
   resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz#65049ef7c6be7857da742cd028f97602ce209635"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6370,6 +6370,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swiper@^11.2.10:
+  version "11.2.10"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.2.10.tgz#ed0b17286b56f7fe8d4b46ed61e6e0bd8daaccad"
+  integrity sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==
+
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.2.tgz#ab4984340d30cb9989a490032f086dbb8b56d872"


### PR DESCRIPTION
## 어떤 이유로 PR를 하셨나요?
 - [x] feature 병합
 - [x] 버그 수정
 - [x] 코드 개선
 - [x] 코드 수정
 - [x] 배포
 - [ ] 기타(아래에 자세한 내용 기입해주세요)
 
 ## 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요
- 마이 로드 리스트 페이지 퍼블리싱 완료

- **iconify 설치 && IconifyIcon.tsx 컴포넌트 생성** ‼️
  - 피그마 확인해보니, icon을 iconify 사용해주신 걸로 보여 설치했습니다.
  - svg로 import 해서 사용해주신것 같아보였는데, https://icon-sets.iconify.design/tdesign/?keyword=tdesign 에서 해당하는 아이콘 찾아서 material-symbols:unpaved-road 이런식으로 icon 에 값을 넣어주세요!
  +) 현재 material-symbols, streamline-ultimate, tdesign 등 다양한 목록에서 가져오고 있는 것 같습니다! 보통 iconify를 사용하는 경우, 하나만 선택해서 해당 폴더에서 해당하는 아이콘을 통일되게 사용하는 경우가 많습니다. 통일해서 사용해보는걸 고려해봐도 좋을 것 같아요~ (다시 다 아이콘 찾아야하니.. 시간이 된다면..)
 
- header height 41px로 설정 추가 (피그마 기준)
  - 만약 header, footer(탭) 높이 변경된다면, Layout 부분에서도 꼭! 변경이 필요합니다.
  - tab도 70px으로 현재 되어있는 것 같아서, Layout에서 변경해 둔 상태입니다! 참고부탁드려요!
  
- <Font 에 fontWeight 설정해도 안먹던 이슈 수정

-----------------

### 📌 [기획적 논의 필요 부분]
> 1. 검색 탭의 경우, 정해진 값들이 있는건지 또는 백엔드에서 내려주는 목록 리스트 api가 있는건지?
>     - 목록 리스트를 내려주는 것 이라면, 아이콘은 어떻게 할지
>     - 정해진 거라면, 어떻게 목록을 구성할 것인지?
> 2. 뒤로 가기 어떻게 처리할건지? 
> (ex. 1 depth 이후부터는 헤더에 로고 아이콘 없어지고, 뒤로가기 컴포넌트 구현 || 그건 유저에게 맡긴기...🥲)

  
 ## PR하기 전에 확인해주세요
 - [x] 로컬테스트를 진행하셨나요?
 - [x] 머지할 브랜치를 확인하셨나요?
     
 ## 관련 이슈 번호
 - #35 